### PR TITLE
Automatically update from upstream 

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,23 @@
+name: Update from upstream cask definition
+
+on:
+  # Run every 4 hours.
+  schedule:
+    - cron: "0 */4 * * *"
+
+  # Also allow manual triggering.
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout both superproject and submodule.
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      # Run Make script to pull in changes from upstream.
+      - name: Update from upstream
+        run: make update

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "homebrew-cask"]
+	path = homebrew-cask
+	url = https://github.com/Homebrew/homebrew-cask
+	branch = master

--- a/Casks/vscodium.rb
+++ b/Casks/vscodium.rb
@@ -1,17 +1,28 @@
-cask 'vscodium' do
-  version '1.51.1'
-  sha256 '730ededf174ebced2a90bddbd87862c2a06869783853ad956af72c85f5b57e70'
+cask "vscodium" do
+  version "1.51.1"
+  sha256 "730ededf174ebced2a90bddbd87862c2a06869783853ad956af72c85f5b57e70"
 
   url "https://github.com/VSCodium/vscodium/releases/download/#{version}/VSCodium.#{version}.dmg"
-  appcast 'https://github.com/VSCodium/vscodium/releases.atom'
-  name 'VSCodium (with original Visual Studio Code Extensions Gallery configuration)'
-  homepage 'https://github.com/VSCodium/vscodium'
+  appcast "https://github.com/VSCodium/vscodium/releases.atom"
+  name "VSCodium (with original Visual Studio Code Extensions Gallery configuration)"
+  desc "Binary releases of VS Code without MS branding/telemetry/licensing (and with original Visual Studio Code Extensions Gallery configuration)"
+  homepage "https://github.com/VSCodium/vscodium"
 
   auto_updates false
-  conflicts_with cask: 'visual-studio-code'
+  conflicts_with cask: "visual-studio-code"
 
-  app 'VSCodium.app'
+  app "VSCodium.app"
   binary "#{appdir}/VSCodium.app/Contents/Resources/app/bin/code"
+
+  zap trash: [
+    "~/Library/Application Support/VSCodium",
+    "~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.visualstudio.code.oss.sfl*",
+    "~/Library/Logs/VSCodium",
+    "~/Library/Preferences/com.visualstudio.code.oss.helper.plist",
+    "~/Library/Preferences/com.visualstudio.code.oss.plist",
+    "~/Library/Saved Application State/com.visualstudio.code.oss.savedState",
+    "~/.vscode-oss",
+  ]
 
   postflight do
     require 'json'
@@ -25,7 +36,7 @@ cask 'vscodium' do
 
     # Disable auto-updating in user-level VSCodium settings, or the above extensions patch would be overwritten.
     settings_file_path = "#{Dir.home}/Library/Application Support/VSCodium/User/settings.json"
-    
+
     # Read exisitng settings file if it exists.
     begin
       settings = JSON.load(File.read(settings_file_path))
@@ -39,21 +50,11 @@ cask 'vscodium' do
 
     # macOS quarantines apps when an internal file is modified; undo that to allow the app to open.
     system_command 'xattr',
-                   args:  [ '-r',
+                    args: [ '-r',
                             '-d', 'com.apple.quarantine',
                             "#{appdir}/VSCodium.app"
                           ]
   end
-
-  zap trash: [
-               '~/Library/Application Support/VSCodium',
-               '~/Library/Application Support/com.apple.sharedfilelist/com.apple.LSSharedFileList.ApplicationRecentDocuments/com.visualstudio.code.oss.sfl*',
-               '~/Library/Logs/VSCodium',
-               '~/Library/Preferences/com.visualstudio.code.oss.helper.plist',
-               '~/Library/Preferences/com.visualstudio.code.oss.plist',
-               '~/Library/Saved Application State/com.visualstudio.code.oss.savedState',
-               '~/.vscode-oss',
-             ]
 
   caveats 'Do not use the built-in update functionality with this version of VSCodium or the extensions marketplace settings will be overwritten; use `brew cask upgrade` instead.'
 end

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+# Do nothing by default.
+.PHONY: default
+default: ;
+
+
+# Set some "configuration" variables.
+SUBMODULE_DIRECTORY := homebrew-cask
+CASK_PATH           := Casks/vscodium.rb
+
+# Set a variable for the commit at the start of this invocation (which will be changed during the update).
+PREVIOUS_COMMIT      = $(shell git -C "${SUBMODULE_DIRECTORY}" rev-parse HEAD)
+
+# Update the submodule to the latest version, and cherry-pick any changes to the cask file.
+# Note the use of spaces and tabs below for comments and commands, respectively.
+# - `make` will not accept comments preceded by tabs (or, rather, will treat them as shell commands) but using spaces is fine, even if the formatting is a little weird.
+.PHONY: update
+update:
+    # Print the submodule's current commit information for logging.
+	@git submodule status -- "${SUBMODULE_DIRECTORY}"
+    # Update the cask submodule to the latest remote commit, which prints the new commit if it's different.
+	@git submodule update --remote -- "${SUBMODULE_DIRECTORY}"
+    # Extract any submodule commits affecting the cask file into patches, then apply to the superproject.
+	@git -C "${SUBMODULE_DIRECTORY}" format-patch --stdout "${PREVIOUS_COMMIT}..HEAD" -- "${CASK_PATH}" | git am
+    # Amend the submodule update onto the last cask-update patch, but only if an update was already applied and we're on `master`.
+    # We neither want to amend an already-pushed commit nor have a bunch of useless commits that just bump the submodule version without also bumping the cask version.
+	@if [ "$$(git rev-parse --abbrev-ref HEAD)" = 'master' ] && [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/master)" ]; then \
+		git commit --amend --no-edit -- "${SUBMODULE_DIRECTORY}"; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ update:
 	@git submodule update --remote -- "${SUBMODULE_DIRECTORY}"
     # Extract any submodule commits affecting the cask file into patches, then apply to the superproject.
 	@git -C "${SUBMODULE_DIRECTORY}" format-patch --stdout "${PREVIOUS_COMMIT}..HEAD" -- "${CASK_PATH}" | git am
-    # Amend the submodule update onto the last cask-update patch, but only if an update was already applied and we're on `master`.
+    # Amend the submodule update onto the last cask-update patch, but only if an update was already applied in the previous step.
     # We neither want to amend an already-pushed commit nor have a bunch of useless commits that just bump the submodule version without also bumping the cask version.
-	@if [ "$$(git rev-parse --abbrev-ref HEAD)" = 'master' ] && [ "$$(git rev-parse HEAD)" != "$$(git rev-parse origin/master)" ]; then \
+	@if [ "$$(git rev-parse --abbrev-ref HEAD)" = 'master' ] && [ "$$(git rev-parse HEAD)" != "$$(git rev-parse @{u})" ]; then \
 		git commit --amend --no-edit -- "${SUBMODULE_DIRECTORY}"; \
 	fi


### PR DESCRIPTION
This should hopefully prevent this repository from getting too out of date, cherry-picking any changes to the cask formula from the upstream cask repo on a 4-hour interval. Can also be done manually with `make update`.

@Crazor may have taken me a while longer to get around to, but hopefully this helps!