### PR TITLE
Update Usage section to reflect new brew syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Additionally, auto-updates are disabled in your user `settings.json` as this pat
 
 ## Usage ##
 
-`brew cask install mplew-is/vscodium/vscodium-with-vscode-extensions`
+`brew install mplew-is/vscodium/vscodium-with-vscode-extensions`
 
 
 ## Updating and automation ##


### PR DESCRIPTION
Homebrew has removed the cask command a while ago, so the README is
updated to reflect that.